### PR TITLE
Replace channel_data's type from Map with PresenceChannelData

### DIFF
--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
@@ -1,11 +1,10 @@
 package com.github.dtaniwaki.akka_pusher
 
 import akka.actor._
+import com.github.dtaniwaki.akka_pusher.PusherMessages._
 import com.typesafe.scalalogging.StrictLogging
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
-import PusherMessages._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class PusherActor extends Actor with StrictLogging {
   implicit val system = ActorSystem("pusher")

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
@@ -92,7 +92,7 @@ class PusherClient(config: Config = ConfigFactory.load())(implicit val system: A
     request(HttpRequest(method = GET, uri = uri.toString)).map{ new Users(_) }
   }
 
-  def authenticate(channel: String, socketId: String, data: Option[PresenceChannelData] = None): AuthenticatedParams = {
+  def authenticate(channel: String, socketId: String, data: Option[ChannelData] = None): AuthenticatedParams = {
     val serializedData = data.map(_.toJson.compactPrint)
     val signingStrings = serializedData.foldLeft(List(socketId, channel))(_ :+ _)
     AuthenticatedParams(s"$key:${signature(signingStrings.mkString(":"))}", serializedData)

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupport.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupport.scala
@@ -36,6 +36,28 @@ trait PusherJsonSupport extends DefaultJsonProtocol {
     }
   }
 
+  implicit object ChannelDataJsonSupport extends RootJsonFormat[PresenceChannelData] {
+    override def write(data: PresenceChannelData): JsValue =
+      data.userInfo.map { userInfo =>
+        JsObject(
+          "user_id" -> JsString(data.userId),
+          "user_info" -> userInfo.toJson
+        )
+      }.getOrElse(
+        JsObject("user_id" -> JsString(data.userId))
+      )
+
+
+    override def read(json: JsValue): PresenceChannelData =
+      json.asJsObject.getFields("user_id", "user_info") match {
+        case Seq(JsString(userId), userInfo) =>
+          PresenceChannelData(userId, Some(userInfo.convertTo[Map[String, String]]))
+        case Seq(JsString(userId), JsNull) =>
+          PresenceChannelData(userId, None)
+        case x => deserializationError("ChannelData is expected: " + x)
+      }
+  }
+
   implicit val AuthRequestJsonSupport = jsonFormat(AuthRequest.apply, "socket_id", "channel_name")
   implicit object WebhookRequestJsonSupport extends RootJsonFormat[WebhookRequest] {
     def write(res: WebhookRequest): JsValue = {

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupport.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupport.scala
@@ -36,8 +36,8 @@ trait PusherJsonSupport extends DefaultJsonProtocol {
     }
   }
 
-  implicit object ChannelDataJsonSupport extends RootJsonFormat[PresenceChannelData] {
-    override def write(data: PresenceChannelData): JsValue =
+  implicit object ChannelDataJsonSupport extends RootJsonFormat[ChannelData] {
+    override def write(data: ChannelData): JsValue =
       data.userInfo.map { userInfo =>
         JsObject(
           "user_id" -> JsString(data.userId),
@@ -48,12 +48,12 @@ trait PusherJsonSupport extends DefaultJsonProtocol {
       )
 
 
-    override def read(json: JsValue): PresenceChannelData =
+    override def read(json: JsValue): ChannelData =
       json.asJsObject.getFields("user_id", "user_info") match {
         case Seq(JsString(userId), userInfo) =>
-          PresenceChannelData(userId, Some(userInfo.convertTo[Map[String, String]]))
+          ChannelData(userId, Some(userInfo.convertTo[Map[String, String]]))
         case Seq(JsString(userId), JsNull) =>
-          PresenceChannelData(userId, None)
+          ChannelData(userId, None)
         case x => deserializationError("ChannelData is expected: " + x)
       }
   }

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherMessages.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherMessages.scala
@@ -1,6 +1,6 @@
 package com.github.dtaniwaki.akka_pusher
 
-import com.github.dtaniwaki.akka_pusher.PusherModels.PresenceChannelData
+import com.github.dtaniwaki.akka_pusher.PusherModels.ChannelData
 
 object PusherMessages {
   case class TriggerMessage(
@@ -23,7 +23,7 @@ object PusherMessages {
   case class AuthenticateMessage(
     socketId: String,
     channel: String,
-    data: Option[PresenceChannelData] = None
+    data: Option[ChannelData] = None
   )
   case class ValidateSignatureMessage(
     key: String,

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherMessages.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherMessages.scala
@@ -1,5 +1,7 @@
 package com.github.dtaniwaki.akka_pusher
 
+import com.github.dtaniwaki.akka_pusher.PusherModels.PresenceChannelData
+
 object PusherMessages {
   case class TriggerMessage(
     channel: String,
@@ -21,7 +23,7 @@ object PusherMessages {
   case class AuthenticateMessage(
     socketId: String,
     channel: String,
-    data: Option[Map[String, String]] = None
+    data: Option[PresenceChannelData] = None
   )
   case class ValidateSignatureMessage(
     key: String,

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherModels.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherModels.scala
@@ -17,7 +17,7 @@ object PusherModels {
     auth: String,
     channelData: Option[String] = None
   )
-  case class PresenceChannelData(
+  case class ChannelData(
     /**
      * unique identifier for that user
      */

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherModels.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherModels.scala
@@ -17,4 +17,14 @@ object PusherModels {
     auth: String,
     channelData: Option[String] = None
   )
+  case class PresenceChannelData(
+    /**
+     * unique identifier for that user
+     */
+    userId: String,
+    /**
+     * optional set of identifying information
+     */
+    userInfo: Option[Map[String, String]] = None
+  )
 }

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherActorSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherActorSpec.scala
@@ -68,7 +68,7 @@ class PusherActorSpec extends Specification
     "with AuthenticateMessage" should {
       "returns ResponseMessage with AuthenticatedParams" in {
         val actorRef = system.actorOf(PusherActor.props)
-        val channelData = PresenceChannelData(
+        val channelData = ChannelData(
           userId = "test_user",
           userInfo = Some(Map("foo" -> "bar"))
         )
@@ -77,7 +77,7 @@ class PusherActorSpec extends Specification
       }
       "returns ResponseMessage with AuthenticatedParams, userInfo not included" in {
         val actorRef = system.actorOf(PusherActor.props)
-        val channelData = PresenceChannelData("test_user")
+        val channelData = ChannelData("test_user")
         val future = actorRef ? AuthenticateMessage("GET", "123.234", Some(channelData))
         awaitResult(future) === ResponseMessage(AuthenticatedParams("key:5be264b14524c93bafdc7dbc0bdba9dd782f00a2e310bcb55ef76b26b6841f44", Some("""{"user_id":"test_user"}""")))
       }

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherActorSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherActorSpec.scala
@@ -68,8 +68,18 @@ class PusherActorSpec extends Specification
     "with AuthenticateMessage" should {
       "returns ResponseMessage with AuthenticatedParams" in {
         val actorRef = system.actorOf(PusherActor.props)
-        val future = actorRef ? AuthenticateMessage("GET", "123.234", Some(Map("foo" -> "bar")))
-        awaitResult(future) === ResponseMessage(AuthenticatedParams("key:ea737f47cb5f96df1717289fd9bf6a2588e44265dcf2504321308b22f618bb39", Some("""{"foo":"bar"}""")))
+        val channelData = PresenceChannelData(
+          userId = "test_user",
+          userInfo = Some(Map("foo" -> "bar"))
+        )
+        val future = actorRef ? AuthenticateMessage("GET", "123.234", Some(channelData))
+        awaitResult(future) === ResponseMessage(AuthenticatedParams("key:5e76b03a1e16bda68b183aef8ca71fb2fad9773eae977ff3912bca2ec2d3a7e0", Some("""{"user_id":"test_user","user_info":{"foo":"bar"}}""")))
+      }
+      "returns ResponseMessage with AuthenticatedParams, userInfo not included" in {
+        val actorRef = system.actorOf(PusherActor.props)
+        val channelData = PresenceChannelData("test_user")
+        val future = actorRef ? AuthenticateMessage("GET", "123.234", Some(channelData))
+        awaitResult(future) === ResponseMessage(AuthenticatedParams("key:5be264b14524c93bafdc7dbc0bdba9dd782f00a2e310bcb55ef76b26b6841f44", Some("""{"user_id":"test_user"}""")))
       }
     }
     "with ValidateSignatureMessage" should {

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
@@ -144,12 +144,12 @@ class PusherClientSpec extends Specification
   "#authenticate" should {
     "return an authenticatedParams" in {
       val pusher = spy(new PusherClient())
-      val channelData = PresenceChannelData(
+      val channelData = ChannelData(
         userId = "test user",
         userInfo = Some(Map("foo" -> "bar"))
       )
-      val res = pusher.authenticate("GET", "123.234", Some(channelData))
-      res === AuthenticatedParams("key:b5c954ab1e7b8da2fb91ccfd3b1ceb18465d9eedb3f5782dc909c584e656d791", Some("""{"user_id":"test user","user_info":{"foo":"bar"}}"""))
+      val res = pusher.authenticate("channel", "123.234", Some(channelData))
+      res === AuthenticatedParams("key:bd773eb7c2796dcfc240a894f0f4b5a438e901d97d2d474ea9fa34310d3e8357", Some("""{"user_id":"test user","user_info":{"foo":"bar"}}"""))
     }
     "without data" in {
       "return an authenticatedParams" in {

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
@@ -144,9 +144,12 @@ class PusherClientSpec extends Specification
   "#authenticate" should {
     "return an authenticatedParams" in {
       val pusher = spy(new PusherClient())
-
-      val res = pusher.authenticate("channel", "123.234", Some(Map("foo" -> "bar")))
-      res === AuthenticatedParams("key:89728bf2c4f1c2ba483805632d85848f6cb350777a00632ec45958c616978414", Some("""{"foo":"bar"}"""))
+      val channelData = PresenceChannelData(
+        userId = "test user",
+        userInfo = Some(Map("foo" -> "bar"))
+      )
+      val res = pusher.authenticate("GET", "123.234", Some(channelData))
+      res === AuthenticatedParams("key:b5c954ab1e7b8da2fb91ccfd3b1ceb18465d9eedb3f5782dc909c584e656d791", Some("""{"user_id":"test user","user_info":{"foo":"bar"}}"""))
     }
     "without data" in {
       "return an authenticatedParams" in {


### PR DESCRIPTION
This PR will provide a  type information for JSON payload where the client will receive on `pusher:subscription_succeeded` in presence channel like below:

``` json
{
  "user_id": "foo",
  "user_info": {
    "key": "value"
  }
}
```

So far, user_info is typed as `Map[String, String]`
