### PR TITLE
[WIP] Fix json transformation, etc

### DIFF
--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
@@ -1,7 +1,7 @@
 package com.github.dtaniwaki.akka_pusher
 
 import akka.actor._
-import spray.json.JsonFormat
+import spray.json.{JsonFormat,JsString, JsValue, JsonWriter}
 import scala.concurrent.{ Future, Await, Awaitable }
 import scala.concurrent.duration._
 import com.github.dtaniwaki.akka_pusher.PusherMessages._
@@ -12,6 +12,9 @@ import PusherModels.ChannelData
 
 class PusherActor[T : JsonFormat] extends Actor with StrictLogging {
   implicit val system = ActorSystem("pusher")
+  implicit object stringJsonFormat extends JsonWriter[String] {
+    override def write(obj: String): JsValue = JsString(obj)
+  }
 
   val pusher = new PusherClient()
 

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
@@ -19,8 +19,8 @@ class PusherActor[T : JsonFormat] extends Actor with StrictLogging {
   val pusher = new PusherClient()
 
   override def receive: Receive = {
-    case TriggerMessage(event, channel, message, socketId) =>
-      sender ! new ResponseMessage(Await.result(pusher.trigger(event, channel, message, socketId), 5 seconds))
+    case TriggerMessage(channel, event, message, socketId) =>
+      sender ! new ResponseMessage(Await.result(pusher.trigger(channel, event, message, socketId), 5 seconds))
     case ChannelMessage(channel, attributes) =>
       sender ! new ResponseMessage(Await.result(pusher.channel(channel, attributes), 5 seconds))
     case ChannelsMessage(prefixFilter, attributes) =>

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
@@ -47,7 +47,7 @@ class PusherClient(config: Config = ConfigFactory.load())(implicit val system: A
   else
     "http"
 
-  def trigger[T](event: String, channel: String, data: T, socketId: Option[String] = None)(implicit writer: JsonWriter[T]): Future[Result] = {
+  def trigger[T](channel: String, event: String, data: T, socketId: Option[String] = None)(implicit writer: JsonWriter[T]): Future[Result] = {
     validateChannel(channel)
     socketId.map(validateSocketId)
     var uri = generateUri(path = Uri.Path(s"/apps/$appId/events"))

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupport.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupport.scala
@@ -32,14 +32,15 @@ trait PusherJsonSupport extends DefaultJsonProtocol {
         "channel" -> JsString(event.channel),
         "user_id" -> JsString(event.userId),
         "event" -> JsString(event.event),
-        "data" -> event.data.toJson,
+        "data" -> JsString(event.data.toJson.toString),
         "socket_id" -> JsString(event.socketId)
       )
     }
+
     def read(json: JsValue): ClientEvent = {
       json.asJsObject.getFields("name", "channel", "user_id", "event", "data", "socket_id") match {
-        case Seq(JsString(name), JsString(channel), JsString(userId), JsString(event), data, JsString(socketId)) =>
-          ClientEvent(name, channel, userId, event, data.convertTo[Map[String, String]], socketId)
+        case Seq(JsString(name), JsString(channel), JsString(userId), JsString(event), JsString(data), JsString(socketId)) =>
+          ClientEvent(name, channel, userId, event, data.parseJson.convertTo[Map[String, String]], socketId)
       }
     }
   }
@@ -76,14 +77,14 @@ trait PusherJsonSupport extends DefaultJsonProtocol {
         case event: ClientEvent => event.toJson
       }.toVector
       JsObject(
-        "time_ms" -> JsNumber((res.timeMs.getMillis / 1000).toLong),
+        "time_ms" -> JsNumber(res.timeMs.getMillis / 1000L),
         "events" -> JsArray(events)
       )
     }
     def read(json: JsValue): WebhookRequest = {
       json.asJsObject.getFields("time_ms", "events") match {
         case Seq(JsNumber(timeMs), JsArray(events)) =>
-          WebhookRequest(new DateTime(timeMs.toLong * 1000), events.map { event =>
+          WebhookRequest(new DateTime(timeMs.toLong * 1000L), events.map { event =>
             event.asJsObject.getFields("name")(0) match {
               case JsString("client_event")     => event.convertTo[ClientEvent]
               case JsString("channel_occupied") => event.convertTo[ChannelOccupiedEvent]

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupport.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupport.scala
@@ -36,7 +36,6 @@ trait PusherJsonSupport extends DefaultJsonProtocol {
         "socket_id" -> JsString(event.socketId)
       )
     }
-
     def read(json: JsValue): ClientEvent = {
       json.asJsObject.getFields("name", "channel", "user_id", "event", "data", "socket_id") match {
         case Seq(JsString(name), JsString(channel), JsString(userId), JsString(event), JsString(data), JsString(socketId)) =>
@@ -85,12 +84,12 @@ trait PusherJsonSupport extends DefaultJsonProtocol {
       json.asJsObject.getFields("time_ms", "events") match {
         case Seq(JsNumber(timeMs), JsArray(events)) =>
           WebhookRequest(new DateTime(timeMs.toLong * 1000L), events.map { event =>
-            event.asJsObject.getFields("name")(0) match {
-              case JsString("client_event")     => event.convertTo[ClientEvent]
-              case JsString("channel_occupied") => event.convertTo[ChannelOccupiedEvent]
-              case JsString("channel_vacated")  => event.convertTo[ChannelVacatedEvent]
-              case JsString("member_added")     => event.convertTo[MemberAddedEvent]
-              case JsString("member_removed")   => event.convertTo[MemberRemovedEvent]
+            event.asJsObject.getFields("name") match {
+              case Seq(JsString("client_event"))     => event.convertTo[ClientEvent]
+              case Seq(JsString("channel_occupied")) => event.convertTo[ChannelOccupiedEvent]
+              case Seq(JsString("channel_vacated"))  => event.convertTo[ChannelVacatedEvent]
+              case Seq(JsString("member_added"))     => event.convertTo[MemberAddedEvent]
+              case Seq(JsString("member_removed"))   => event.convertTo[MemberRemovedEvent]
               case _ => null
             }
           }.filter(_ != null))

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherActorSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherActorSpec.scala
@@ -7,6 +7,7 @@ import akka.util.Timeout
 import org.specs2.mutable.Specification
 import org.specs2.specification.process.RandomSequentialExecution
 import org.specs2.mock.Mockito
+import spray.json.{JsString, JsValue, JsonWriter}
 import scala.concurrent.{Future, Await}
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
@@ -27,6 +28,9 @@ class PusherActorSpec extends Specification
 {
   implicit val system = ActorSystem("pusher")
   implicit val timeout = Timeout(5 seconds)
+//  implicit object stringJsonFormat extends JsonWriter[String] {
+//    override def write(obj: String): JsValue = JsString(obj)
+//  }
 
   private def awaitResult[A](future: Future[A]) = Await.result(future, Duration.Inf)
 
@@ -34,7 +38,7 @@ class PusherActorSpec extends Specification
     "with TriggerMessage" in {
       "returns ResponseMessage with Result" in {
         val pusher = mock[PusherClient].smart
-        pusher.trigger(anyString, anyString, anyString, any) returns Future(Result(""))
+        pusher.trigger(anyString, anyString, anyString, any)(any) returns Future(Result(""))
         val actorRef = system.actorOf(Props(classOf[TestActor], pusher))
 
         val future = actorRef ? TriggerMessage("event", "channel", "message", Some("123.234"))

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
@@ -43,7 +43,7 @@ class PusherClientSpec extends Specification
         override def request(req: HttpRequest) = Future("")
       }
 
-      val res = pusher.trigger("event", "channel", "message", Some("123.234"))
+      val res = pusher.trigger("channel", "event", "message", Some("123.234"))
       awaitResult(res) === Result("")
     }
     "without socket" in {
@@ -52,7 +52,7 @@ class PusherClientSpec extends Specification
           override def request(req: HttpRequest) = Future("")
         }
 
-        val res = pusher.trigger("event", "channel", "message")
+        val res = pusher.trigger("channel", "event", "message")
         awaitResult(res) === Result("")
       }
     }

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
@@ -1,22 +1,18 @@
 package com.github.dtaniwaki.akka_pusher
 
-import org.specs2.mutable.{After, Specification}
-import org.specs2.specification.process.RandomSequentialExecution
-import org.specs2.mock.Mockito
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.HttpMethods._
-import akka.http.scaladsl.model.HttpProtocols._
-import akka.http.scaladsl.model.MediaTypes._
-import akka.testkit._
-import spray.json.{JsString, JsValue, JsonWriter}
-import scala.concurrent.{Future, Await}
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
+import com.github.dtaniwaki.akka_pusher.PusherModels._
 import com.typesafe.config.ConfigFactory
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.process.RandomSequentialExecution
 import spray.json.DefaultJsonProtocol._
+import spray.json.{JsString, JsValue, JsonWriter}
 
-import PusherModels._
-import PusherExceptions._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
 class PusherClientSpec extends Specification
   with RandomSequentialExecution
@@ -25,9 +21,6 @@ class PusherClientSpec extends Specification
 {
   private def awaitResult[A](future: Future[A]) = Await.result(future, Duration.Inf)
   implicit val system = ActorSystem("pusher")
-  implicit object stringJsonFormat extends JsonWriter[String] {
-    override def write(obj: String): JsValue = JsString(obj)
-  }
 
   "#constructor" should {
     "accept the config by argument" in {

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
@@ -7,6 +7,8 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.HttpProtocols._
 import akka.http.scaladsl.model.MediaTypes._
+import akka.testkit._
+import spray.json.{JsString, JsValue, JsonWriter}
 import scala.concurrent.{Future, Await}
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -22,6 +24,10 @@ class PusherClientSpec extends Specification
   with Mockito
 {
   private def awaitResult[A](future: Future[A]) = Await.result(future, Duration.Inf)
+  implicit val system = ActorSystem("pusher")
+  implicit object stringJsonFormat extends JsonWriter[String] {
+    override def write(obj: String): JsValue = JsString(obj)
+  }
 
   "#constructor" should {
     "accept the config by argument" in {

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupportSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupportSpec.scala
@@ -18,14 +18,19 @@ class PusherJsonSupportSpec extends Specification
   "WebhookRequestJsonSupport" should {
     "with multiple different events" in {
       "read from json object" in {
-        val event1 = ClientEvent(name = "client_event", channel = "test", userId = "123", data = Map("foo" -> "bar"), event = "event", socketId = "123.234")
+        val data: Map[String, String] = Map("foo" -> "bar")
+        val event1 = ClientEvent(name = "client_event", channel = "test", userId = "123", data = data, event = "event", socketId = "123.234")
         val event2 = ChannelOccupiedEvent("channel_occupied", "test")
-        """{"time_ms": 12345, "events":[{"name":"client_event", "channel":"test", "user_id":"123", "data": {"foo":"bar"}, "event":"event", "socket_id":"123.234"},{"name":"channel_occupied","channel":"test"}]}""".parseJson.convertTo[WebhookRequest] === WebhookRequest(new DateTime(12345000), List(event1, event2))
+        val dataString = data.toJson.toString.replace("\"", "\\\"")
+        s"""{"time_ms": 12345, "events":[{"name": "client_event", "channel": "test", "user_id": "123", "data": "$dataString", "event": "event", "socket_id": "123.234"},{"name":"channel_occupied","channel":"test"}]}"""
+          .parseJson.convertTo[WebhookRequest] === WebhookRequest(new DateTime(12345000), List(event1, event2))
       }
       "write to json object" in {
-        val event1 = ClientEvent(name = "client_event", channel = "test", userId = "123", data = Map("foo" -> "bar"), event = "event", socketId = "123.234")
+        val data: Map[String, String] = Map("foo" -> "bar")
+        val event1 = ClientEvent(name = "client_event", channel = "test", userId = "123", data = data, event = "event", socketId = "123.234")
         val event2 = ChannelOccupiedEvent("channel_occupied", "test")
-        WebhookRequest(new DateTime(12345000), List(event1, event2)).toJson === """{"time_ms": 12345, "events":[{"name":"client_event", "channel":"test", "user_id":"123", "data": {"foo":"bar"}, "event":"event", "socket_id":"123.234"},{"name":"channel_occupied","channel":"test"}]}""".parseJson
+        val dataString = data.toJson.toString.replace("\"", "\\\"")
+        WebhookRequest(new DateTime(12345000), List(event1, event2)).toJson === s"""{"time_ms": 12345, "events":[{"name": "client_event", "channel": "test", "user_id": "123", "data": "$dataString", "event": "event", "socket_id": "123.234"},{"name":"channel_occupied","channel":"test"}]}""".parseJson
       }
     }
     "with invalid event" in {
@@ -35,12 +40,16 @@ class PusherJsonSupportSpec extends Specification
     }
     "with client event" in {
       "read from json object" in {
-        val event = ClientEvent(name = "client_event", channel = "test", userId = "123", data = Map("foo" -> "bar"), event = "event", socketId = "123.234")
-        """{"time_ms": 12345, "events":[{"name":"client_event", "channel":"test", "user_id":"123", "data": {"foo":"bar"}, "event":"event", "socket_id":"123.234"}]}""".parseJson.convertTo[WebhookRequest] === WebhookRequest(new DateTime(12345000), List(event))
+        val data: Map[String, String] = Map("foo" -> "bar")
+        val event = ClientEvent(name = "client_event", channel = "test", userId = "123", data = data, event = "event", socketId = "123.234")
+        val dataString = data.toJson.toString.replace("\"", "\\\"")
+        s"""{"time_ms": 12345, "events":[{"name": "client_event", "channel": "test", "user_id": "123", "data": "$dataString", "event": "event", "socket_id": "123.234"}]}""".parseJson.convertTo[WebhookRequest] === WebhookRequest(new DateTime(12345000), List(event))
       }
       "write to json object" in {
-        val event = ClientEvent(name = "client_event", channel = "test", userId = "123", data = Map("foo" -> "bar"), event = "event", socketId = "123.234")
-        WebhookRequest(new DateTime(12345000), List(event)).toJson === """{"time_ms": 12345, "events":[{"name":"client_event", "channel":"test", "user_id":"123", "data": {"foo":"bar"}, "event":"event", "socket_id":"123.234"}]}""".parseJson
+        val data: Map[String, String] = Map("foo" -> "bar")
+        val event = ClientEvent(name = "client_event", channel = "test", userId = "123", data = data, event = "event", socketId = "123.234")
+        val dataString = data.toJson.toString.replace("\"", "\\\"")
+        WebhookRequest(new DateTime(12345000), List(event)).toJson === s"""{"time_ms": 12345, "events":[{"name": "client_event", "channel": "test", "user_id": "123", "data": "$dataString", "event": "event", "socket_id": "123.234"}]}""".parseJson
       }
     }
     "with channel_occupied event" in {

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupportSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupportSpec.scala
@@ -1,6 +1,8 @@
 package com.github.dtaniwaki.akka_pusher
 
-import spray.json._
+import com.github.dtaniwaki.akka_pusher.PusherEvents._
+import com.github.dtaniwaki.akka_pusher.PusherRequests._
+import com.github.nscala_time.time.Imports._
 import org.specs2.mutable.Specification
 import org.specs2.specification.process.RandomSequentialExecution
 import org.joda.time.format._
@@ -9,6 +11,7 @@ import com.github.nscala_time.time.Imports._
 import PusherRequests._
 import PusherEvents._
 import PusherModels._
+import spray.json._
 
 class PusherJsonSupportSpec extends Specification
   with SpecHelper
@@ -36,6 +39,9 @@ class PusherJsonSupportSpec extends Specification
     "with invalid event" in {
       "does not read from json object" in {
         """{"time_ms": 12345, "events":[{"name":"invalid_event", "channel":"test"}]}""".parseJson.convertTo[WebhookRequest] === WebhookRequest(new DateTime(12345000), List())
+      }
+      "does not read from json object without name" in {
+        """{"time_ms": 12345, "events":[{"channel": "test"}]}""".parseJson.convertTo[WebhookRequest] === WebhookRequest(new DateTime(12345000), List())
       }
     }
     "with client event" in {


### PR DESCRIPTION
In this PR:
- add conversion code for `ClientEvent.data`  (event's `data` field is sent as a string-serialized form as written in [Pusher Protocol](https://pusher.com/docs/pusher_protocol#events).
- make `PusherClient#trigger` generic and change its signature to conform to other Pusher client
