### PR TITLE
Fix WebhookRequest deserialization

### DIFF
--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupport.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupport.scala
@@ -86,12 +86,12 @@ trait PusherJsonSupport extends DefaultJsonProtocol {
       json.asJsObject.getFields("time_ms", "events") match {
         case Seq(JsNumber(timeMs), JsArray(events)) =>
           WebhookRequest(new DateTime(timeMs.toLong * 1000), events.map { event =>
-            event.asJsObject.getFields("name")(0) match {
-              case JsString("client_event")     => event.convertTo[ClientEvent]
-              case JsString("channel_occupied") => event.convertTo[ChannelOccupiedEvent]
-              case JsString("channel_vacated")  => event.convertTo[ChannelVacatedEvent]
-              case JsString("member_added")     => event.convertTo[MemberAddedEvent]
-              case JsString("member_removed")   => event.convertTo[MemberRemovedEvent]
+            event.asJsObject.getFields("name") match {
+              case Seq(JsString("client_event"))     => event.convertTo[ClientEvent]
+              case Seq(JsString("channel_occupied")) => event.convertTo[ChannelOccupiedEvent]
+              case Seq(JsString("channel_vacated"))  => event.convertTo[ChannelVacatedEvent]
+              case Seq(JsString("member_added"))     => event.convertTo[MemberAddedEvent]
+              case Seq(JsString("member_removed"))   => event.convertTo[MemberRemovedEvent]
               case _ => null
             }
           }.filter(_ != null))

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupportSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupportSpec.scala
@@ -1,6 +1,8 @@
 package com.github.dtaniwaki.akka_pusher
 
-import spray.json._
+import com.github.dtaniwaki.akka_pusher.PusherEvents._
+import com.github.dtaniwaki.akka_pusher.PusherRequests._
+import com.github.nscala_time.time.Imports._
 import org.specs2.mutable.Specification
 import org.specs2.specification.process.RandomSequentialExecution
 import org.joda.time.format._
@@ -9,6 +11,7 @@ import com.github.nscala_time.time.Imports._
 import PusherRequests._
 import PusherEvents._
 import PusherModels._
+import spray.json._
 
 class PusherJsonSupportSpec extends Specification
   with SpecHelper
@@ -31,6 +34,9 @@ class PusherJsonSupportSpec extends Specification
     "with invalid event" in {
       "does not read from json object" in {
         """{"time_ms": 12345, "events":[{"name":"invalid_event", "channel":"test"}]}""".parseJson.convertTo[WebhookRequest] === WebhookRequest(new DateTime(12345000), List())
+      }
+      "does not read from json object without name" in {
+        """{"time_ms": 12345, "events":[{"channel": "test"}]}""".parseJson.convertTo[WebhookRequest] === WebhookRequest(new DateTime(12345000), List())
       }
     }
     "with client event" in {


### PR DESCRIPTION
Although unlikely, when trying to deserialize `JsObject` into `WebhookRequest`, it throws `java.lang.IndexOutOfBoundsException` if name property is missing.  Since your code has a catch-all case matching (`case _ => null`), I think it would be more appropriate to let it handle that situation.
