### PR TITLE
Make PusherClient#trigger generic

### DIFF
--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
@@ -1,22 +1,15 @@
 package com.github.dtaniwaki.akka_pusher
 
+import spray.json.DefaultJsonProtocol._
 import akka.actor._
-import spray.json.{JsonFormat,JsString, JsValue, JsonWriter}
-import scala.concurrent.{ Future, Await, Awaitable }
-import scala.concurrent.duration._
 import com.github.dtaniwaki.akka_pusher.PusherMessages._
 import com.typesafe.scalalogging.StrictLogging
-import scala.concurrent.ExecutionContext.Implicits.global
 
-import PusherModels.ChannelData
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class PusherActor extends Actor with StrictLogging {
   implicit val system = ActorSystem("pusher")
-
-  implicit object jsValueJsonFormat extends JsonWriter[JsValue] {
-    override def write(obj: JsValue): JsValue = obj
-  }
-
   val pusher = new PusherClient()
 
   override def receive: Receive = {

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
@@ -1,27 +1,24 @@
 package com.github.dtaniwaki.akka_pusher
 
-import spray.json._
-import spray.http.Uri
-import scala.concurrent.{ ExecutionContext, Future }
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{ Failure, Success, Try }
 import akka.actor.ActorSystem
-import akka.stream.{Materializer, ActorMaterializer}
-import akka.stream.scaladsl.{ Source, Flow, Sink }
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.HttpMethods._
-import akka.http.scaladsl.model.HttpProtocols._
-import akka.http.scaladsl.model.MediaTypes._
-import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.HttpsContext
-import com.typesafe.config.{ConfigFactory, Config}
+import akka.http.scaladsl.model.HttpMethods._
+import akka.http.scaladsl.model.MediaTypes._
+import akka.http.scaladsl.model._
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, Source}
+import com.github.dtaniwaki.akka_pusher.PusherExceptions._
+import com.github.dtaniwaki.akka_pusher.PusherModels._
+import com.github.dtaniwaki.akka_pusher.Utils._
+import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
+import spray.http.Uri
+import spray.json._
 
-import Utils._
-import PusherModels._
-import PusherExceptions._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Success
 
 class PusherClient(config: Config = ConfigFactory.load())(implicit val system: ActorSystem = ActorSystem("pusher-client"))
   extends PusherJsonSupport
@@ -47,21 +44,25 @@ class PusherClient(config: Config = ConfigFactory.load())(implicit val system: A
   else
     "http"
 
-  def trigger(event: String, channel: String, message: String, socketId: Option[String] = None): Future[Result] = {
+  def trigger[T: JsonWriter](event: String, channel: String, data: T, socketId: Option[String] = None): Future[Result] = {
     validateChannel(channel)
     socketId.map(validateSocketId)
     var uri = generateUri(path = Uri.Path(s"/apps/$appId/events"))
 
-    val data = Map(
-      "data" -> Some(Map("message" -> message).toJson.toString),
+    val body = JsObject(Map(
+      "data" -> Some(data.toJson.compactPrint),
       "name" -> Some(event),
       "channel" -> Some(channel),
       "socket_id" -> socketId
-    ).filter(_._2.isDefined).mapValues(_.get)
+    )
+      .filter(_._2.isDefined)
+      .mapValues(_.get)
+      .mapValues(JsString(_)))
+      .toString
 
-    uri = signUri("POST", uri, Some(data))
+    uri = signUri("POST", uri, Some(body))
 
-    request(HttpRequest(method = POST, uri = uri.toString, entity = HttpEntity(ContentType(`application/json`), data.toJson.compactPrint))).map{ new Result(_) }
+    request(HttpRequest(method = POST, uri = uri.toString, entity = HttpEntity(ContentType(`application/json`), body))).map{ new Result(_) }
   }
 
   def channel(channel: String, attributes: Option[Seq[String]] = None): Future[Channel] = {
@@ -98,7 +99,7 @@ class PusherClient(config: Config = ConfigFactory.load())(implicit val system: A
     request(HttpRequest(method = GET, uri = uri.toString)).map(_.parseJson.convertTo[List[User]])
   }
 
-  def authenticate[T](channel: String, socketId: String, data: Option[ChannelData[T]] = Option.empty[ChannelData[String]])(implicit writer: JsonWriter[T]): AuthenticatedParams = {
+  def authenticate[T: JsonWriter](channel: String, socketId: String, data: Option[ChannelData[T]] = Option.empty[ChannelData[String]]): AuthenticatedParams = {
     val serializedData = data.map(_.toJson.compactPrint)
     val signingStrings = serializedData.foldLeft(List(socketId, channel))(_ :+ _)
     AuthenticatedParams(s"$key:${signature(signingStrings.mkString(":"))}", serializedData)
@@ -135,7 +136,7 @@ class PusherClient(config: Config = ConfigFactory.load())(implicit val system: A
     Uri(scheme = scheme, authority = Uri.Authority(Uri.Host(host)), path = path)
   }
 
-  private def signUri(method: String, uri: Uri, data: Option[Map[String, String]] = None): Uri = {
+  private def signUri(method: String, uri: Uri, data: Option[String] = None): Uri = {
     var signedUri = uri
     var params = List(
       ("auth_key", key),
@@ -143,7 +144,7 @@ class PusherClient(config: Config = ConfigFactory.load())(implicit val system: A
       ("auth_version", "1.0")
     )
     if (data.isDefined) {
-      val serializedData = data.get.toJson.compactPrint
+      val serializedData = data.get
       params = params :+ ("body_md5", md5(serializedData))
     }
     signedUri = signedUri.withQuery(params ++ uri.query.toList: _*)

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupport.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherJsonSupport.scala
@@ -115,7 +115,7 @@ trait PusherJsonSupport extends DefaultJsonProtocol {
       }
     }
   }
-  implicit val ChannelJsonSupport = jsonFormat(Channel.apply _, "occupied", "user_count", "subscription_count")
+  implicit val ChannelJsonSupport = jsonFormat(Channel.apply, "occupied", "user_count", "subscription_count")
   implicit object UserListJsonSupport extends RootJsonFormat[List[User]] {
     def write(users: List[User]): JsValue = {
       JsObject("users" -> JsArray(users.map(_.toJson).toVector))

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherMessages.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherMessages.scala
@@ -1,7 +1,7 @@
 package com.github.dtaniwaki.akka_pusher
 
-import spray.json.{JsonFormat, JsValue}
 import com.github.dtaniwaki.akka_pusher.PusherModels.ChannelData
+import spray.json.JsValue
 
 object PusherMessages {
   case class TriggerMessage(

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/Utils.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/Utils.scala
@@ -1,10 +1,9 @@
 package com.github.dtaniwaki.akka_pusher
 
-import java.security.MessageDigest
-import java.security.NoSuchAlgorithmException
 import java.math.BigInteger
-import javax.crypto.spec.SecretKeySpec
+import java.security.MessageDigest
 import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 
 object Utils {
   def byteArrayToString(data: Array[Byte]) = {

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherActorSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherActorSpec.scala
@@ -1,21 +1,19 @@
 package com.github.dtaniwaki.akka_pusher
 
 import akka.actor.{ActorSystem, Props}
-import akka.testkit.TestActorRef
 import akka.pattern.ask
 import akka.util.Timeout
+import com.github.dtaniwaki.akka_pusher.PusherMessages._
+import com.github.dtaniwaki.akka_pusher.PusherModels._
+import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.process.RandomSequentialExecution
-import org.specs2.mock.Mockito
-import scala.concurrent.{Future, Await}
-import scala.concurrent.duration._
-import scala.util.{ Failure, Success, Try }
-import scala.concurrent.ExecutionContext.Implicits.global
-import spray.json._
 import spray.json.DefaultJsonProtocol._
+import spray.json._
 
-import PusherModels._
-import PusherMessages._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
 class TestActor(_pusher: PusherClient) extends PusherActor {
   override val pusher = _pusher
@@ -35,7 +33,7 @@ class PusherActorSpec extends Specification
     "with TriggerMessage" in {
       "returns ResponseMessage with Result" in {
         val pusher = mock[PusherClient].smart
-        pusher.trigger(anyString, anyString, anyString, any) returns Future(Result(""))
+        pusher.trigger(anyString, anyString, anyString, any)(any) returns Future(Result(""))
         val actorRef = system.actorOf(Props(classOf[TestActor], pusher))
 
         val future = actorRef ? TriggerMessage("event", "channel", "message", Some("123.234"))

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
@@ -1,20 +1,16 @@
 package com.github.dtaniwaki.akka_pusher
 
-import org.specs2.mutable.{After, Specification}
-import org.specs2.specification.process.RandomSequentialExecution
-import org.specs2.mock.Mockito
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.HttpMethods._
-import akka.http.scaladsl.model.HttpProtocols._
-import akka.http.scaladsl.model.MediaTypes._
-import scala.concurrent.{Future, Await}
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
+import com.github.dtaniwaki.akka_pusher.PusherModels._
 import com.typesafe.config.ConfigFactory
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.process.RandomSequentialExecution
 import spray.json.DefaultJsonProtocol._
 
-import PusherModels._
-import PusherExceptions._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
 class PusherClientSpec extends Specification
   with RandomSequentialExecution


### PR DESCRIPTION
This PR makes `PusherClient#trigger` generic and in order to be so, it requires `JsonWriter` implicitly for JSON serialization.
