### PR TITLE
Fix trigger's signature (channel comes first then event follows that)

### DIFF
--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
@@ -13,8 +13,8 @@ class PusherActor extends Actor with StrictLogging {
   val pusher = new PusherClient()
 
   override def receive: Receive = {
-    case TriggerMessage(event, channel, message, socketId) =>
-      sender ! new ResponseMessage(Await.result(pusher.trigger(event, channel, message, socketId), 5 seconds))
+    case TriggerMessage(channel, event, message, socketId) =>
+      sender ! new ResponseMessage(Await.result(pusher.trigger(channel, event, message, socketId), 5 seconds))
     case ChannelMessage(channel, attributes) =>
       sender ! new ResponseMessage(Await.result(pusher.channel(channel, attributes), 5 seconds))
     case ChannelsMessage(prefixFilter, attributes) =>

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
@@ -44,7 +44,7 @@ class PusherClient(config: Config = ConfigFactory.load())(implicit val system: A
   else
     "http"
 
-  def trigger[T: JsonWriter](event: String, channel: String, data: T, socketId: Option[String] = None): Future[Result] = {
+  def trigger[T: JsonWriter](channel: String, event: String, data: T, socketId: Option[String] = None): Future[Result] = {
     validateChannel(channel)
     socketId.map(validateSocketId)
     var uri = generateUri(path = Uri.Path(s"/apps/$appId/events"))

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
@@ -33,7 +33,7 @@ class PusherClientSpec extends Specification
         override def request(req: HttpRequest) = Future("")
       }
 
-      val res = pusher.trigger("event", "channel", "message", Some("123.234"))
+      val res = pusher.trigger("channel", "event", "message", Some("123.234"))
       awaitResult(res) === Result("")
     }
     "without socket" in {
@@ -42,7 +42,7 @@ class PusherClientSpec extends Specification
           override def request(req: HttpRequest) = Future("")
         }
 
-        val res = pusher.trigger("event", "channel", "message")
+        val res = pusher.trigger("channel", "event", "message")
         awaitResult(res) === Result("")
       }
     }


### PR DESCRIPTION
This PR will make trigger's signature consistent with other pusher library, where channel name comes first and event name comes next.

c.f. [Pusher API libraries](https://pusher.com/docs/libraries)
