### PR TITLE
Implement PusherClient#trigger that accepts more than one channels

### DIFF
--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
@@ -17,7 +17,7 @@ class PusherActor extends Actor with StrictLogging {
       someSocketId.fold(
         sender ! new ResponseMessage(Await.result(pusher.trigger(channels, event, message), 5 seconds))
       ) { socketId =>
-        sender ! new ResponseMessage(Await.result(pusher.trigger(channels, event, message, socketId), 5 seconds))
+        sender ! new ResponseMessage(Await.result(pusher.trigger(channels, event, message, Some(socketId)), 5 seconds))
       }
     case TriggerMessage(channel, event, message, socketId) =>
       sender ! new ResponseMessage(Await.result(pusher.trigger(channel, event, message, socketId), 5 seconds))

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
@@ -13,6 +13,12 @@ class PusherActor extends Actor with StrictLogging {
   val pusher = new PusherClient()
 
   override def receive: Receive = {
+    case TriggerMessageToChannels(channels, event, message, someSocketId) =>
+      someSocketId.fold(
+        sender ! new ResponseMessage(Await.result(pusher.trigger(channels, event, message), 5 seconds))
+      ) { socketId =>
+        sender ! new ResponseMessage(Await.result(pusher.trigger(channels, event, message, socketId), 5 seconds))
+      }
     case TriggerMessage(channel, event, message, socketId) =>
       sender ! new ResponseMessage(Await.result(pusher.trigger(channel, event, message, socketId), 5 seconds))
     case ChannelMessage(channel, attributes) =>

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
@@ -24,8 +24,7 @@ import scala.util.Success
 class PusherClient(config: Config = ConfigFactory.load())(implicit val system: ActorSystem = ActorSystem("pusher-client"))
   extends PusherJsonSupport
   with StrictLogging
-  with PusherValidator
-{
+  with PusherValidator {
   val host = config.as[Option[String]]("pusher.host").getOrElse("api.pusherapp.com")
   val appId = config.getString("pusher.appId")
   val key = config.getString("pusher.key")
@@ -33,12 +32,14 @@ class PusherClient(config: Config = ConfigFactory.load())(implicit val system: A
   val ssl = config.as[Option[Boolean]]("pusher.ssl").getOrElse(false)
 
   implicit val materializer = ActorMaterializer()(system)
-
-  private val (pool, scheme) = if (ssl) {
-    (Http(system).cachedHostConnectionPoolTls[Int](host), "https")
-  } else {
-    (Http(system).cachedHostConnectionPool[Int](host), "http")
-  }
+  private val pool = if (ssl)
+    Http(system).cachedHostConnectionPoolTls[Int](host)
+  else
+    Http(system).cachedHostConnectionPool[Int](host)
+  private val scheme = if (ssl)
+    "https"
+  else
+    "http"
 
   def trigger[T: JsonWriter](channel: String, event: String, data: T, socketId: Option[String] = None): Future[Result] = {
     validateChannel(channel)
@@ -54,6 +55,40 @@ class PusherClient(config: Config = ConfigFactory.load())(implicit val system: A
       .filter(_._2.isDefined)
       .mapValues(_.get)
       .mapValues(JsString(_)))
+      .toString
+
+    uri = signUri("POST", uri, Some(body))
+
+    request(HttpRequest(method = POST, uri = uri.toString, entity = HttpEntity(ContentType(`application/json`), body))).map{ new Result(_) }
+  }
+
+  def trigger[T: JsonWriter](channels: Seq[String], event: String, data: T): Future[Result] = {
+    channels.foreach(validateChannel)
+    var uri = generateUri(path = Uri.Path(s"/apps/$appId/events"))
+
+    val body = JsObject(
+        "data" -> JsString(data.toJson.compactPrint),
+        "name" -> JsString(event),
+        "channels" -> JsArray(channels.map(JsString.apply).toVector)
+      )
+      .toString
+
+    uri = signUri("POST", uri, Some(body))
+
+    request(HttpRequest(method = POST, uri = uri.toString, entity = HttpEntity(ContentType(`application/json`), body))).map{ new Result(_) }
+  }
+
+  def trigger[T: JsonWriter](channels: Seq[String], event: String, data: T, socketId: String): Future[Result] = {
+    channels.foreach(validateChannel)
+    validateSocketId(socketId)
+    var uri = generateUri(path = Uri.Path(s"/apps/$appId/events"))
+
+    val body = JsObject(
+      "data" -> JsString(data.toJson.compactPrint),
+      "name" -> JsString(event),
+      "channels" -> JsArray(channels.map(JsString.apply).toVector),
+      "socket_id" -> JsString(socketId)
+    )
       .toString
 
     uri = signUri("POST", uri, Some(body))

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherMessages.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherMessages.scala
@@ -4,6 +4,12 @@ import com.github.dtaniwaki.akka_pusher.PusherModels.ChannelData
 import spray.json.JsValue
 
 object PusherMessages {
+  case class TriggerMessageToChannels(
+    channels: Seq[String],
+    event: String,
+    message: JsValue,
+    socketId: Option[String] = None
+  )
   case class TriggerMessage(
     channel: String,
     event: String,

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherActorSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherActorSpec.scala
@@ -30,6 +30,26 @@ class PusherActorSpec extends Specification
   private def awaitResult[A](future: Future[A]) = Await.result(future, Duration.Inf)
 
   "#receive" should {
+    "with TriggerMessageToChannels containing socketId" in {
+      "returns ResponseMessage with Result" in {
+        val pusher = mock[PusherClient].smart
+        pusher.trigger(anyListOf[String], anyString, any, any)(any) returns Future(Result(""))
+        val actorRef = system.actorOf(Props(classOf[TestActor], pusher))
+
+        val future = actorRef ? TriggerMessageToChannels(List("channel1", "channel2"), "event", JsString("message"), Some("123.234"))
+        awaitResult(future) === ResponseMessage(Result(""))
+      }
+    }
+    "with TriggerMessageToChannels not containing socketId" in {
+      "returns ResponseMessage with Result" in {
+        val pusher = mock[PusherClient].smart
+        pusher.trigger(anyListOf[String], anyString, any)(any) returns Future(Result(""))
+        val actorRef = system.actorOf(Props(classOf[TestActor], pusher))
+
+        val future = actorRef ? TriggerMessageToChannels(List("channel1", "channel2"), "event", JsString("message"), None)
+        awaitResult(future) === ResponseMessage(Result(""))
+      }
+    }
     "with TriggerMessage" in {
       "returns ResponseMessage with Result" in {
         val pusher = mock[PusherClient].smart

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
@@ -63,7 +63,7 @@ class PusherClientSpec extends Specification
         override def request(req: HttpRequest) = Future("")
       }
 
-      val res = pusher.trigger(List("channel1", "channel1"), "event", "message", "123.234")
+      val res = pusher.trigger(List("channel1", "channel1"), "event", "message", Some("123.234"))
       awaitResult(res) === Result("")
     }
   }

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/PusherClientSpec.scala
@@ -27,7 +27,7 @@ class PusherClientSpec extends Specification
       pusher.secret === "secret0"
     }
   }
-  "#trigger" should {
+  "#trigger(channel: String, event: String, data: T, socketId: Option[String] = None)" should {
     "make a request to pusher" in {
       val pusher = new PusherClient() {
         override def request(req: HttpRequest) = Future("")
@@ -45,6 +45,26 @@ class PusherClientSpec extends Specification
         val res = pusher.trigger("channel", "event", "message")
         awaitResult(res) === Result("")
       }
+    }
+  }
+  "#trigger(channels: Seq[String], event: String, data: T)" should {
+    "make a request to pusher to the multiple channels" in {
+      val pusher = new PusherClient() {
+        override def request(req: HttpRequest) = Future("")
+      }
+
+      val res = pusher.trigger(List("channel1", "channel1"), "event", "message")
+      awaitResult(res) === Result("")
+    }
+  }
+  "#trigger(channels: Seq[String], event: String, data: T, socketId: String)" should {
+    "make a request to pusher to the multiple channels" in {
+      val pusher = new PusherClient() {
+        override def request(req: HttpRequest) = Future("")
+      }
+
+      val res = pusher.trigger(List("channel1", "channel1"), "event", "message", "123.234")
+      awaitResult(res) === Result("")
     }
   }
   "#channel" should {


### PR DESCRIPTION
By this PR, the client can send an event to multiple channels.
## 

_NOTE:_
Scala compiler doesn't allow overloaded method alternatives with optional parameters.  In other words, the code like below won't compile.

``` scala
// compilation error with message "in class PusherClient, multiple overloaded alternatives of method trigger define default arguments." 
def trigger(channel: String, event: String, data: T, socketId: Option[String] = None) = ...
def trigger(channels: Seq[String], event: String, data: T, socketId: Option[String] = None) = ...
```

So in this PR I had to add two more `trigger` overloads like below:

``` scala
def trigger(channel: String, event: String, data: T, socketId: Option[String] = None)
// added
def trigger(channels: Seq[String], event: String, data: T)
def trigger(channels: Seq[String], event: String, data: T, socketId: String)
```

Of course there can be other interface, such as:

``` scala
def trigger(channel: String, event: String, data: T, socketId: Option[String])
def trigger(channels: Seq[String], event: String, data: T, socketId: Option[String])
```
## 

Anyway I'll leave it to you to decide which kind of overloads should be defined for `trigger` method.  
