### PR TITLE
Fix signed string

### DIFF
--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
@@ -185,8 +185,8 @@ class PusherClient(config: Config = ConfigFactory.load())(implicit val system: A
       params = params :+ ("body_md5", md5(serializedData))
     }
     signedUri = signedUri.withQuery(Uri.Query((params ++ uri.query().toList): _*))
-
-    val signingString = s"$method\n${uri.path}\n${signedUri.queryString()}"
+    val normalizedQuery = normalizeQuery(signedUri.query())
+    val signingString = s"$method\n${uri.path}\n${normalizedQuery.toString}"
     signedUri.withQuery(Uri.Query((signedUri.query().toList :+ ("auth_signature", signature(signingString))): _*))
   }
 

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
@@ -15,6 +15,7 @@ import com.github.dtaniwaki.akka_pusher.attributes.{ PusherChannelsAttributes, P
 import com.typesafe.config.{ Config, ConfigFactory }
 import net.ceedubs.ficus.Ficus._
 import akka.http.scaladsl.model.Uri
+import org.joda.time.DateTimeUtils
 import org.slf4j.LoggerFactory
 import spray.json._
 import scala.concurrent.ExecutionContext
@@ -177,7 +178,7 @@ class PusherClient(config: Config = ConfigFactory.load())(implicit val system: A
     var signedUri = uri
     var params = List(
       ("auth_key", key),
-      ("auth_timestamp", (System.currentTimeMillis / 1000).toString),
+      ("auth_timestamp", (DateTimeUtils.currentTimeMillis() / 1000).toString),
       ("auth_version", "1.0")
     )
     if (data.isDefined) {

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/Utils.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/Utils.scala
@@ -5,6 +5,8 @@ import java.security.MessageDigest
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
+import akka.http.scaladsl.model.Uri
+
 object Utils {
   val HEX = 16
   val LENGTH = 32
@@ -37,5 +39,9 @@ object Utils {
 
     val bigInteger = new BigInteger(1, digest)
     String.format("%0" + (digest.length << 1) + "x", bigInteger)
+  }
+
+  def normalizeQuery(query: Uri.Query): Uri.Query = {
+    Uri.Query(query.map { case (k, v) => (k.toString.toLowerCase, v) }.sortBy(_._1): _*)
   }
 }

--- a/src/test/scala/com/github/dtaniwaki/akka_pusher/UtilsSpec.scala
+++ b/src/test/scala/com/github/dtaniwaki/akka_pusher/UtilsSpec.scala
@@ -1,5 +1,6 @@
 package com.github.dtaniwaki.akka_pusher
 
+import akka.http.scaladsl.model.Uri
 import org.specs2.mutable.Specification
 import org.specs2.specification.process.RandomSequentialExecution
 
@@ -23,6 +24,14 @@ class UtilsSpec extends Specification
     "generate hex digest sha256 of strings with 日本語" in {
       Utils.sha256("secret", "Digest me 日本語") === "b52446253d26c4bd19c1200e310ddc8ff3678f3422b2df6c47b153209cadec0b"
       // echo -n "Digest me 日本語" | openssl dgst -sha256 -hmac "secret"
+    }
+  }
+  "#normalizeQuery" should {
+    "make the key lower case" in {
+      Utils.normalizeQuery(Uri.Query(Map("abc" -> "abc", "CDE" -> "CDE"))).toString === "abc=abc&cde=CDE"
+    }
+    "make the order alphabetical" in {
+      Utils.normalizeQuery(Uri.Query(Map("cde" -> "cde", "abc" -> "abc"))).toString === "abc=abc&cde=cde"
     }
   }
 }


### PR DESCRIPTION
This is the bug fix reported by @yueki
https://github.com/dtaniwaki/akka-pusher/issues/28

I followed the doc of [Pusher API](https://pusher.com/docs/rest_api#auth-signature) so it also fixes the upper case key bug.

I also use exact match on called URL validations.
