### PR TITLE
Replace akka-http-core-experimental with akka-http-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,13 @@ cache:
     - $HOME/.sbt/boot/scala-$TRAVIS_SCALA_VERSION
 
 scala:
-  - 2.10.6
   - 2.11.7
 
 jdk:
   - oraclejdk8
 
 script:
-  - "[ \"$TRAVIS_SCALA_VERSION\" != \"2.10.6\" ] || sbt ++$TRAVIS_SCALA_VERSION clean test"
-  - "[ \"$TRAVIS_SCALA_VERSION\" == \"2.10.6\" ] || sbt ++$TRAVIS_SCALA_VERSION clean coverage test"
+  - "sbt ++$TRAVIS_SCALA_VERSION clean coverage test"
 
 after_success:
   - pip install --user codecov && codecov

--- a/build.sbt
+++ b/build.sbt
@@ -3,27 +3,20 @@ organization := "com.github.dtaniwaki"
 name := "akka-pusher"
 
 scalaVersion := "2.11.7"
-crossScalaVersions := Seq("2.10.6", "2.11.7")
+crossScalaVersions := Seq("2.11.7")
 
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
 
-val akkaV = "2.3.14"
-val akkaHttpV = "2.0.1"
-val sprayJsonV = "1.3.2"
+val akkaV = "2.4.9"
 val specs2V = "3.6.4"
 
 val developmentDependencies = Seq(
-  "com.typesafe.akka"   %%  "akka-actor"    % akkaV,
-  "com.typesafe.akka"   %%  "akka-http-core-experimental" % akkaHttpV,
-  "io.spray"            %%  "spray-json" % sprayJsonV,
-  "com.github.nscala-time" %% "nscala-time" % "2.2.0",
-  "org.slf4j"           %   "slf4j-api"     % "1.7.12"
-)
-val developmentDependencies_2_11 = Seq(
-  "net.ceedubs"                %% "ficus"         % "1.1.2"
-)
-val developmentDependencies_2_10 = Seq(
-  "net.ceedubs"                %% "ficus"             % "1.0.1"
+  "com.typesafe.akka"       %%  "akka-actor"                        % akkaV,
+  "com.typesafe.akka"       %%  "akka-http-core"                    % akkaV,
+  "com.typesafe.akka"       %%  "akka-http-spray-json-experimental" % akkaV,
+  "com.github.nscala-time"  %%  "nscala-time"                       % "2.2.0",
+  "org.slf4j"               %   "slf4j-api"                         % "1.7.12",
+  "net.ceedubs"             %%  "ficus"                             % "1.1.2"
 )
 val testDependencies = Seq(
   "com.typesafe.akka"   %%  "akka-testkit"  % akkaV % "test",
@@ -32,12 +25,7 @@ val testDependencies = Seq(
   "org.specs2"          %%  "specs2-matcher-extra" % specs2V % "test",
   "org.specs2"          %%  "specs2-mock"   % specs2V % "test"
 )
-libraryDependencies <++= (scalaVersion) {
-  case v if v.startsWith("2.10.") =>
-    developmentDependencies ++ developmentDependencies_2_10 ++ testDependencies
-  case v if v.startsWith("2.11.") =>
-    developmentDependencies ++ developmentDependencies_2_11 ++ testDependencies
-}
+libraryDependencies ++= developmentDependencies ++ testDependencies
 
 fork in Test := true
 parallelExecution in Test := true

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherActor.scala
@@ -23,7 +23,16 @@ class PusherActor(
   }
 
   implicit val system = context.system
-  implicit val ec: ExecutionContext = system.dispatcher
+
+  implicit val ec: ExecutionContext = {
+    val config = system.settings.config
+    if (config.hasPath("pusher.dispatcher")) {
+      system.dispatchers.lookup("pusher.dispatcher")
+    } else {
+      system.dispatcher
+    }
+  }
+
   private lazy val logger = LoggerFactory.getLogger(getClass)
 
   val batchSize = config.as[Option[Int]]("pusher.batchSize").getOrElse(10) // Undoc but just in case...

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
@@ -23,7 +23,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{ Try, Success, Failure }
 
-class PusherClient(config: Config = ConfigFactory.load())(implicit val system: ActorSystem = ActorSystem("pusher-client"))
+class PusherClient(config: Config = ConfigFactory.load())(implicit val system: ActorSystem = ActorSystem("pusher-client"), ec: ExecutionContext)
     extends PusherValidator
     with PusherJsonSupport {
   private lazy val logger = LoggerFactory.getLogger(getClass)
@@ -41,7 +41,6 @@ class PusherClient(config: Config = ConfigFactory.load())(implicit val system: A
   logger.debug(s"ssl.......... ${ssl}")
 
   implicit val materializer = ActorMaterializer()(system)
-  implicit val ec: ExecutionContext = system.dispatcher
   protected val pool: Flow[(HttpRequest, Int), (Try[HttpResponse], Int), Any] = if (ssl) {
     Http(system).cachedHostConnectionPoolHttps[Int](host)
   } else {

--- a/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
+++ b/src/main/scala/com/github/dtaniwaki/akka_pusher/PusherClient.scala
@@ -43,7 +43,7 @@ class PusherClient(config: Config = ConfigFactory.load())(implicit val system: A
   implicit val materializer = ActorMaterializer()(system)
   implicit val ec: ExecutionContext = system.dispatcher
   protected val pool: Flow[(HttpRequest, Int), (Try[HttpResponse], Int), Any] = if (ssl) {
-    Http(system).cachedHostConnectionPoolTls[Int](host)
+    Http(system).cachedHostConnectionPoolHttps[Int](host)
   } else {
     Http(system).cachedHostConnectionPool[Int](host)
   }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -7,4 +7,14 @@ pusher {
   secret=${?PUSHER_API_SECRET}
   batchTrigger = false
   batchInterval = 1000
+  dispatcher {
+    type = Dispatcher
+    executor = "fork-join-executor"
+    fork-join-executor {
+      parallelism-min = 2
+      parallelism-max = 4
+      parallelism-factor = 2.0
+    }
+  }
 }
+


### PR DESCRIPTION
This PR will update akka libraries, to use akka-pusher with akka-http.
⚠️ after this change, spray can no longer be supported, as it doesn't run with akka-http 2.4.x
